### PR TITLE
DEV3-1036: add terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+*.iml

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,10 @@ version: 0.2
 phases:
   build:
     commands:
-      - cd $CODEBUILD_SRC_DIR/ubuntu/standard/7.0
-      - docker build -t aws/codebuild/standard:7.0 .
-      - cd $CODEBUILD_SRC_DIR/al2/x86_64/standard/5.0
-      - docker build -t aws/codebuild/amazonlinux2-x86_64-standard:5.0 .
+      - cd ubuntu/standard/7.0
+      - ECR_URL=948396734470.dkr.ecr.ap-southeast-2.amazonaws.com/cicd
+      - IMAGE_NAME=codebuild
+      - aws ecr get-login-password  | docker login --username AWS --password-stdin $ECR_URL$/IMAGE_NAME
+      - docker build -t $IMAGE_NAME -f Dockerfile .
+      - docker tag codebuild $ECR_URL/$IMAGE_NAME:latest
+      - docker push $ECR_URL/$IMAGE_NAME:latest

--- a/ubuntu/standard/7.0/Dockerfile
+++ b/ubuntu/standard/7.0/Dockerfile
@@ -44,6 +44,12 @@ RUN set -ex \
           python3-openssl rsync sgml-base sgml-data \
           tar tcl tcl8.6 tk tk-dev unzip wget xfsprogs xml-core xmlto xsltproc \
           libzip-dev vim xvfb xz-utils zip zlib1g-dev git-lfs \
+    # Install Terraform
+    && wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | tee /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+    && gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint \
+    && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list \
+    && apt update \
+    && apt-get install terraform \
     && rm -rf /var/lib/apt/lists/*
 
 ENV LC_CTYPE="C.UTF-8"


### PR DESCRIPTION
`aws-codebuild-docker-images` is not a public image, so have to fork the  repo  and add scripts to it